### PR TITLE
Allow models to be defined without the engine

### DIFF
--- a/ingestion/database.py
+++ b/ingestion/database.py
@@ -78,7 +78,7 @@ class Database:
     def Model(self):  # NOQA, not really serving as a function
         """Return the SQLAlchemy base declarative model."""
         if not self._model_base:
-            self._model_base = declarative_base(bind=self.engine)
+            self._model_base = declarative_base()
 
         return self._model_base
 


### PR DESCRIPTION
Models don't need an engine as long as the session has one. Forcing the
base model class to bind to an engine would mean that the engine would
be needed at class creation time. Due to the way applications are
structured, the connection information isn't available until runtime.
