### PR TITLE
Use the application registry to get current app

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ setup(
     namespace_packages=['ingestion'],
     packages=find_packages(exclude=['tests']),
     install_requires=[
+        'ingestion.service>=0.3.0',
         'setuptools',
         'SQLAlchemy>=1.0.2',
     ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Test utiltities."""
 
+from ingestion.service import registry
 import pytest
 
 
@@ -16,9 +17,26 @@ class Application:
         self.name = 'testing'
         self.settings = settings
 
+        # Register the app with the registry just like a real one would
+        # do.
+        registry.current_application = self
+
 
 @pytest.fixture
-def test_app():
+def clean_up_registry(request):
+    """Clean up the application registry after the test is run."""
+    original = registry._applications
+    registry._applications = []
+
+    def teardown():
+        registry._applications = original
+    request.addfinalizer(teardown)
+
+    return registry
+
+
+@pytest.fixture
+def test_app(clean_up_registry):
     """Return a test application."""
     app = Application(
         DATABASE_USERNAME='test',

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,24 @@
+"""Test handling of apps."""
+
+import pytest
+
+from ingestion.database import get_app
+
+
+def test_get_app_with_app():
+    """Test that get_app returns the provided app."""
+    expected = object()
+    actual = get_app(expected)
+    assert actual == expected
+
+
+def test_get_app_with_registry(test_app):
+    """Test that get_app returns an app from the registry."""
+    actual = get_app()
+    assert actual == test_app
+
+
+def test_get_app_with_no_app_raises_runtimeerror():
+    """Test that get_app raises RuntimeError when there is no app."""
+    with pytest.raises(RuntimeError):
+        get_app()


### PR DESCRIPTION
In order to connect to a database, an application's settings are needed.
Because an instance of `Database` is needed at compile time, no
application can be associated with the instance. This would require
explicitly setting one after the fact. This is bad.

The application registry can be used to obtain an application when none
has been associated with the instance directly.
