### PR TITLE
Remove get_app

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,23 +2,26 @@
 
 import pytest
 
-from henson_database import get_app
+from henson import Application
+from henson_database import Database
 
 
-def test_get_app_with_app():
-    """Test that get_app returns the provided app."""
-    expected = object()
-    actual = get_app(expected)
-    assert actual == expected
+def test_app_access_with_app():
+    """Test that Database.app returns the provided app."""
+    app = Application('test_app')
+    database = Database(app)
+    assert database.app == app
 
 
-def test_get_app_with_registry(test_app):
-    """Test that get_app returns an app from the registry."""
-    actual = get_app()
-    assert actual == test_app
+def test_app_access_with_init_app(test_app):
+    """Test that Database.app returns an app set by init_app."""
+    app = Application('test_app')
+    database = Database()
+    database.init_app(app)
+    assert database.app == app
 
 
-def test_get_app_with_no_app_raises_runtimeerror():
-    """Test that get_app raises RuntimeError when there is no app."""
+def test_app_access_with_no_app_raises_runtimeerror():
+    """Test that Database.app raises RuntimeError when there is no app."""
     with pytest.raises(RuntimeError):
-        get_app()
+        Database().app


### PR DESCRIPTION
current_application and the application stack in Henson are no longer
useful constructs going forward. get_app is removed here in favor of
requiring an application to be explicitly passed to the extension via
the initializer or the init_app method. This change is
forward-compatible with the removal of the current_application proxy and
the application registry from Henson, and no externally exposed API is
affected.
