### PR TITLE
Expose metadata through Database instances

### DIFF
--- a/henson_database/__init__.py
+++ b/henson_database/__init__.py
@@ -83,6 +83,11 @@ class Database(Extension):
         return self._engine
 
     @property
+    def metadata(self):
+        """Return the :class:`~sqlalchemy.MetaData` instance."""
+        return self.Model.metadata
+
+    @property
     def Model(self):  # NOQA, not really serving as a function
         """Return the :func:`~sqlalchemy.ext.declarative.declarative_base`."""
         if not self._model_base:


### PR DESCRIPTION
`Database.Model` has a `metadata` property that can be useful when
interacting with a database and its schema. It becomes easier to access
if its exposed by `Database` instances directly.

Closes #12
