### PR TITLE
Update the Read the Docs domain

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Henson-Database |build status|
 
 A library for using SQLAlchemy with a Henson application.
 
-* `Documentation <https://henson-database.rtfd.org>`_
-* `Installation <https://henson-database.readthedocs.org/en/latest/#installation>`_
-* `Changelog <https://henson-database.readthedocs.org/en/latest/changes.html>`_
+* `Documentation <https://henson-database.readthedocs.io>`_
+* `Installation <https://henson-database.readthedocs.io/en/latest/#installation>`_
+* `Changelog <https://henson-database.readthedocs.io/en/latest/changes.html>`_
 * `Source <https://github.com/iheartradio/Henson-Database>`_

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     version='0.4.0',
     author='Andy Dirnberger, Jon Banafato, and others',
     author_email='henson@iheart.com',
-    url='https://henson-database.rtfd.org',
+    url='https://henson-database.readthedocs.io',
     description='A library for using SQLAlchemy with a Henson application',
     long_description=read('README.rst'),
     license='Apache License, Version 2.0',


### PR DESCRIPTION
Read the Docs has switched from using readthedocs.org to readthedocs.io
for project documentation. It includes the added benefit of having
better HTTPS support.