### PR TITLE
Add support for database migrations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Version 0.4.0
 
 Release TBD
 
+- Support migrations through the Henson CLI
+
 Version 0.3.0
 -------------
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include LICENSE
 include README.rst
 
 recursive-include docs Makefile *.py *.rst
+recursive-include henson_database/templates *.mako *.py
 
 exclude .coveragerc
 exclude .travis.yml

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,3 +1,5 @@
+alembic
 doc8
+Henson[sphinx]
 sphinx>=1.3
 sphinx_rtd_theme

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,12 +26,13 @@ sys.path.insert(0, os.path.abspath('..'))
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+needs_sphinx = '1.3'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'henson.contrib.sphinx',
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx.ext.napoleon',

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,6 +46,7 @@ Contents:
    :maxdepth: 1
 
    api
+   migrations
    changes
 
 

--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -1,0 +1,16 @@
+==========
+Migrations
+==========
+
+Henson-Database offers support for `Alembic <http://alembic.zzzcomputing.com>`_
+migrations. To enable them, install Henson-Database with the migrations extra::
+
+    $ python -m pip install Henson-Database[migrations]
+
+This enables the following commands through the ``db`` namespace::
+
+    $ henson --app APP_PATH db --help
+
+.. hensoncli:: henson_database:Database
+   :prog: henson --app APP_PATH
+   :start_command: db

--- a/henson_database/__init__.py
+++ b/henson_database/__init__.py
@@ -4,7 +4,15 @@ from contextlib import contextmanager
 import os
 import pkg_resources
 
+try:
+    # Try to import Alembic to determine if command line migrations
+    # should be enabled.
+    import alembic.command as alembic
+    from alembic.config import Config as AlembicConfig
+except ImportError:
+    alembic = None
 from henson import Extension
+from henson.cli import register_commands
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
@@ -21,6 +29,13 @@ except pkg_resources.DistributionNotFound:
     __version__ = 'development'
 else:
     __version__ = _dist.version
+
+
+if alembic:
+    # This class is only needed when migrations are enabled.
+    class Config(AlembicConfig):
+        def get_template_directory(self):
+            return os.path.join(os.path.dirname(__file__), 'templates')
 
 
 def from_settings(settings):
@@ -59,7 +74,15 @@ class Database(Extension):
         app (Optional[henson.base.Application]): An application instance
             that has an attribute named settings that contains a mapping
             of settings to interact with a database.
+
+    .. versionchanged:: 0.4.0
+
+        Alembic migrations are supported.
     """
+
+    DEFAULT_SETTINGS = {
+        'DATABASE_MIGRATIONS_DIRECTORY': 'migrations',
+    }
 
     REQUIRED_SETTINGS = (
         'DATABASE_URI',
@@ -124,6 +147,38 @@ class Database(Extension):
 
         return self._model_base
 
+    def register_cli(self):
+        """Register the command line interface.
+
+        .. versionadded:: 0.4.0
+        """
+        # A try/except is being used here rather than suppress so that
+        # any ImportErrors raised as a result of registering the
+        # commands aren't swallowed.
+        try:
+            #
+            import alembic  # NOQA
+        except ImportError:
+            # Don't enable migrations.
+            pass
+        else:
+            # Alembic is installed so the CLI should be enabled.
+            register_commands('db', (
+                branches,
+                current,
+                downgrade,
+                edit,
+                generate,
+                heads,
+                history,
+                init,
+                merge,
+                revision,
+                show,
+                stamp,
+                upgrade,
+            ))
+
     @contextmanager
     def session(self):
         """Yield a context manager for a SQLAlchemy session.
@@ -148,3 +203,223 @@ class Database(Extension):
             self._sessionmaker = sessionmaker(bind=self.engine)
 
         return self._sessionmaker
+
+
+def branches(app, *, verbose: 'use more verbose output' = False):
+    """Show current branch points."""
+    alembic.branches(_get_config(app), verbose=verbose)
+
+
+def current(app, *, verbose: 'use more verbose output' = False):
+    """Display the current revision for a database."""
+    alembic.current(_get_config(app), verbose=verbose)
+
+
+def downgrade(app,
+              revision: 'revision identifier' = '-1',
+              *,
+              sql: (
+                  "don't emit SQL to database - dump to standard "
+                  "output/file instead"
+              ) = False,
+              tag: (
+                  "arbitrary 'tag' name - can be used by custom env.py "
+                  "scripts"
+              ) = None):
+    """Revert to a previous version."""
+    alembic.downgrade(_get_config(app), revision=revision, sql=sql, tag=tag)
+
+
+def edit(app, rev):
+    """Edit revision script(s) using $EDITOR."""
+    alembic.edit(_get_config(app), rev=rev)
+
+
+def generate(app,
+             *,
+             message: "message string to use with 'revision'" = None,
+             sql: (
+                 "don't emit SQL to database - dump to standard "
+                 "output/file instead"
+             ) = False,
+             head: (
+                 'specify head revision or <branchname>@head to base '
+                 'new revision on'
+             ) = 'head',
+             splice: (
+                 "allow a non-head revision as the 'head' to splice "
+                 "onto"
+             ) = False,
+             branch_label: (
+                 'specify a branch label to apply to the new revision') = None,
+             version_path: (
+                 'specify specific path from config for version file') = None,
+             rev_id: (
+                 'specify a hardcoded revision id instead of '
+                 'generating one'
+             ) = None,
+             depends_on: (
+                 'specify one or more revision identifiers which this '
+                 'revision should depend on'
+             ) = None):
+    """Generate a revision (alias for 'revision --autogenerate')."""
+    revision(
+        app,
+        message=message,
+        autogenerate=True,
+        sql=sql,
+        head=head,
+        splice=splice,
+        branch_label=branch_label,
+        version_path=version_path,
+        rev_id=rev_id,
+        depends_on=depends_on,
+    )
+
+
+def heads(app,
+          *,
+          verbose: 'use more verbose output' = False,
+          resolve_dependencies: (
+              'treat dependency versions as down revisions') = False):
+    """Show current available heads in the script directory."""
+    alembic.heads(
+        _get_config(app),
+        verbose=verbose,
+        resolve_dependencies=resolve_dependencies,
+    )
+
+
+def history(app,
+            *,
+            rev_range: (
+                'specify a revision range; format is [start]:[end]') = None,
+            verbose: 'use more verbose output' = False):
+    """List changeset scripts in chronological order."""
+    alembic.history(_get_config(app), rev_range=rev_range, verbose=verbose)
+
+
+def init(app, directory: 'location of scripts directory' = None):
+    """Initialize a new scripts directory."""
+    directory = directory or app.settings['DATABASE_MIGRATIONS_DIRECTORY']
+
+    config = Config()
+    config.set_main_option('script_location', directory)
+    config.config_file_name = os.path.join(directory, 'alembic.ini')
+
+    alembic.init(config, directory=directory, template='henson')
+
+
+def merge(app,
+          revisions: "one or more revisions, or 'heads' for all heads",
+          *,
+          message: "message string to use with 'revision'" = None,
+          branch_label: 'specify a branch apply to the new revision' = None,
+          rev_id: (
+              'specify a hardcoded revision id instead of generating '
+              'one'
+          ) = None):
+    """Merge two revisions together. Creates a new migration file."""
+    alembic.merge(
+        _get_config(app),
+        revisions=revisions,
+        message=message,
+        branch_label=branch_label,
+        rev_id=rev_id,
+    )
+
+
+def revision(app,
+             *,
+             message: "message string to use with 'revision'" = None,
+             autogenerate: (
+                 'populate revision script with candidate migration '
+                 'operations, based on comparison of database to model'
+             ) = False,
+             sql: (
+                 "don't emit SQL to database - dump to standard "
+                 "output/file instead"
+             ) = False,
+             head: (
+                 'specify head revision or <branchname>@head to base '
+                 'new revision on'
+             ) = 'head',
+             splice: (
+                 "allow a non-head revision as the 'head' to splice "
+                 "onto"
+             ) = False,
+             branch_label: (
+                 'specify a branch label to apply to the new revision') = None,
+             version_path: (
+                 'specify specific path from config for version file') = None,
+             rev_id: (
+                 'specify a hardcoded revision id instead of '
+                 'generating one'
+             ) = None,
+             depends_on: (
+                 'specify one or more revision identifiers which this '
+                 'revision should depend on'
+             ) = None):
+    """Create a new revision file."""
+    alembic.revision(
+        _get_config(app),
+        message=message,
+        autogenerate=autogenerate,
+        sql=sql,
+        head=head,
+        splice=splice,
+        branch_label=branch_label,
+        version_path=version_path,
+        rev_id=rev_id,
+        depends_on=depends_on,
+    )
+
+
+def show(app, rev):
+    """Show the revision(s) denoted by the given symbol."""
+    alembic.show(_get_config(app), rev=rev)
+
+
+def stamp(app,
+          revision: 'revision identifier',
+          *,
+          sql: (
+              "don't emit SQL to database - dump to standard "
+              "output/file instead"
+          ) = False,
+          tag: (
+              "arbitrary 'tag' name - can be used by custom env.py "
+              "scripts"
+          ) = None):
+    """‘stamp’ the revision table with the given revision; don’t run any migrations."""  # NOQA
+    alembic.stamp(_get_config(app), revision=revision, sql=sql, tag=tag)
+
+
+def upgrade(app,
+            revision: 'revision identifier' = 'head',
+            *,
+            sql: (
+                "don't emit SQL to database - dump to standard "
+                "output/file instead"
+            ) = False,
+            tag: (
+                "arbitrary 'tag' name - can be used by custom env.py "
+                "scripts"
+            ) = None):
+    """Upgrade to a later version."""
+    alembic.upgrade(_get_config(app), revision=revision, sql=sql, tag=tag)
+
+
+def _get_config(app):
+    directory = app.settings['DATABASE_MIGRATIONS_DIRECTORY']
+    config = Config(os.path.join(directory, 'alembic.ini'))
+    config.set_main_option('script_location', directory)
+
+    # Alembic's env.py needs access to the application instance to get
+    # the metadata for the database. Because Henson has no application
+    # context, there's no way to get the application through the henson
+    # package. Fortuantely Alembic's Config provides an attributes
+    # dictionary to pass arbitrary values into it.
+    config.attributes['henson_application'] = app
+
+    return config

--- a/henson_database/templates/henson/alembic.ini.mako
+++ b/henson_database/templates/henson/alembic.ini.mako
@@ -1,0 +1,66 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts
+script_location = ${script_location}
+
+# template used to generate migration files
+# file_template = %%(rev)s_%%(slug)s
+
+# max length of characters to apply to the
+# "slug" field
+#truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; this defaults
+# to ${script_location}/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path
+# version_locations = %(here)s/bar %(here)s/bat ${script_location}/versions
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/henson_database/templates/henson/env.py
+++ b/henson_database/templates/henson/env.py
@@ -1,0 +1,84 @@
+"""Alembic script."""
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+from logging.config import fileConfig
+import logging
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+fileConfig(config.config_file_name)
+logger = logging.getLogger('alembic.env')
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+henson_app = config.attributes['henson_application']
+config.set_main_option('sqlalchemy.url', henson_app.settings['DATABASE_URI'])
+target_metadata = henson_app.extensions['database'].metadata
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def run_migrations_offline():
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url, target_metadata=target_metadata, literal_binds=True)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    # Don't autogenerate empty migrations. From the Alembic cookbook:
+    # https://alembic.readthedocs.io/en/latest/cookbook.html#don-t-generate-empty-migrations-with-autogenerate  # NOQA
+    def process_revision_directives(context, revision, directives):
+        if getattr(config.cmd_opts, 'autogenerate', False):
+            script = directives[0]
+            if script.upgrade_ops.is_empty():
+                directives[:] = []
+                logger.info('No changes in schema detected.')
+
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix='sqlalchemy.',
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            process_revision_directives=process_revision_directives,
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/henson_database/templates/henson/script.py.mako
+++ b/henson_database/templates/henson/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+exclude = henson_database/templates

--- a/setup.py
+++ b/setup.py
@@ -29,10 +29,17 @@ setup(
     license='Apache License, Version 2.0',
     packages=find_packages(exclude=['tests']),
     zip_safe=False,
+    include_package_data=True,
     install_requires=[
-        'Henson',
+        # 1.1 is required to extend the CLI.
+        'Henson>=1.1',
         'SQLAlchemy>=1.0.2',
     ],
+    extras_require={
+        'migrations': [
+            'alembic',
+        ],
+    },
     tests_require=[
         'pytest',
     ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,25 +1,12 @@
 """Test utiltities."""
 
+from henson import Application
 import pytest
-
-
-class Application:
-    """A stub application that can be used for testing.
-
-    Args:
-        **settings: Keyword arguments that will be used as settings.
-    """
-
-    def __init__(self, **settings):
-        """Initialize the instance."""
-        self.name = 'testing'
-        self.settings = settings
 
 
 @pytest.fixture
 def test_app():
     """Return a test application."""
-    app = Application(
-        DATABASE_URI='sqlite://',
-    )
+    app = Application('tesitng')
+    app.settings['DATABASE_URI'] = 'sqlite://'
     return app


### PR DESCRIPTION
Alembic is a fantastic library that can be used to generate and perform
database migrations using SQLAlchemy. With the addition of support for
CLI extensions in Henson 1.1, Henson-Database can now offer support for
database migrations right through a `henson db` command. All of
Alembic's functionality will be exposed through this new interface.

In order to give Alembic a reference to the application, Henson-Database
relies on `Application.extensions`. Rather than adding this (and any
future additions) to the stub `Application` class used for testing, the
real class will be used for test application instances from now on.