### PR TITLE
Update To Python 3.8 and 3.9, drop support for everything below

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,13 @@ language: python
 
 matrix:
   include:
-    - python: 3.4
-      env: TOX_ENV=py34
-    - python: 3.5
-      env: TOX_ENV=py35
-    - python: 3.6
-      env: TOX_ENV=py36
-    - python: 3.6
+    - python: 3.8
+      env: TOX_ENV=py38
+    - python: 3.9
+      env: TOX_ENV=py39
+    - python: 3.9
       env: TOX_ENV=docs
-    - python: 3.6
+    - python: 3.9
       env: TOX_ENV=pep8
 
 install: pip install tox

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def read(filename):
 setup(
     name='Henson-Database',
     version='0.5.0',
-    author='Andy Dirnberger, Jon Banafato, and others',
+    author='Andy Dirnberger, Jon Banafato, Leonard Bedner, and others',
     author_email='henson@iheart.com',
     url='https://henson-database.readthedocs.io',
     description='A library for using SQLAlchemy with a Henson application',
@@ -53,9 +53,8 @@ setup(
         'Natural Language :: English',
         'Operating System :: POSIX',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3 :: Only',
         'Topic :: Software Development :: Libraries :: Application Frameworks',
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,25 +1,25 @@
 [tox]
-envlist = docs,pep8,py34,py35,py36
+envlist = docs,pep8,py38,py39
 
 [testenv]
 deps =
     coverage
     pytest
 commands =
-    python -m coverage run -m pytest --strict {posargs: tests}
+    python -m coverage run -m pytest --strict-markers {posargs: tests}
     python -m coverage report -m --include="henson_database/*"
 
 [testenv:docs]
-basepython = python3.6
+basepython = python3.9
 deps = -rdocs-requirements.txt
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
     doc8 --allow-long-titles README.rst docs/ --ignore-path docs/_build/
 
 [testenv:pep8]
-basepython = python3.6
+basepython = python3.9
 deps =
     flake8-docstrings
     pep8-naming
 commands =
-    flake8 henson_database
+    flake8 --ignore F722 henson_database


### PR DESCRIPTION
- remove support for Python <= 3.7
- add support for Python >= 3.8
- ignore `pep8` `F722` since `flake8` cannot distinguish between type annotations and argument comments at the moment